### PR TITLE
Fixed the outputfieldmapping

### DIFF
--- a/workshops/Module 5.md
+++ b/workshops/Module 5.md
@@ -72,7 +72,7 @@ Add this outputFieldMapping to the indexer.
 
 ```json
 {
-	  "sourceFieldName": "/document/diseases",
+	  "sourceFieldName": "/document/diseases/*/name",
 	  "targetFieldName": "diseasesPhonetic",
 	  "mappingFunction": null
 }


### PR DESCRIPTION
sourceFieldName should be "/document/diseases/*/name"

Otherwise, it indexes the full object output of the diseases skill

Tested it this this mapping and it looks like this works...