### PR TITLE
removing default result fields so all results are returned by default

### DIFF
--- a/02 - Web UI Template/CognitiveSearch.UI/Search/SearchModel.cs
+++ b/02 - Web UI Template/CognitiveSearch.UI/Search/SearchModel.cs
@@ -28,9 +28,9 @@ namespace CognitiveSearch.UI
 
         private string[] resultFields = new string[]
         {
-            "metadata_storage_path",
-            "metadata_storage_name",
-            "metadata_title",
+            //"metadata_storage_path",
+            //"metadata_storage_name",
+            //"metadata_title",
 
             // Add fields needed to display results cards
 


### PR DESCRIPTION
Removing the default values in result fields so all results are returned by default--this will fix a bug where UI was breaking if documents don't have metadata_title.

The app is already set to default a title to metadata_storage_name if metadata_title does not exist.